### PR TITLE
Add Milvue AI results to workflow

### DIFF
--- a/quimby/diagram-fall-xr.md
+++ b/quimby/diagram-fall-xr.md
@@ -1,7 +1,4 @@
-# Team Quimby
-## Fall Radiograph Flow Chart
 
-```mermaid
 flowchart TD
     Generator[Demo Generator] --> |1a DICOM| QveraIE[Qvera Interface Engine]
     Generator --> |1b DICOM| LaurelBridge
@@ -15,16 +12,19 @@ flowchart TD
     LaurelBridge --> |3c DICOM| Fovia
     LaurelBridge --> |3d DICOM| ACRAssess
     
-    Milvue --> |4 AI Results \n DICOM SR| Fovia
-
+    Milvue --> |4a AI Results DICOM SR| Fovia    
     Visage --> |5 Launch| Fovia
 
     Fovia --> |6 Confirmed Results| LaurelBridge
 
     LaurelBridge --> |7a Confirmed Results| Visage
-    LaurelBridge --> |7b Confirmed Results| NuancePS
-    LaurelBridge --> |7c Confirmed Results| ACRAssess
+    LaurelBridge --> |7b Confirmed Results| Milvue
+    
+    Milvue --> |8a AI Report ORU | NuancePS
 
-    NuancePS --> |8a ORU| Visage
-    NuancePS --> |8c ORU| ACRAssess
+    LaurelBridge --> |9a Confirmed Results| NuancePS
+    LaurelBridge --> |9b Confirmed Results| ACRAssess
+   
+    NuancePS --> |10a ORU| Visage
+    NuancePS --> |10b ORU| ACRAssess
 ```


### PR DESCRIPTION
Hello Mohannad, 

I propose workflow with some changes to present Milvue Reports. 
Milvue would like to present our Generative AI Reports at the demo. 

To put this in focus, i modified the workflow.

- The step 7a (LaurelBridge --> |7b Confirmed Results| Milvue ) will let Milvue access the confirmed results so as to adapt the AI Generated Reports.
Alternately a step ( Fovia --> |6b Confirmed Results| Milvue ) would serve the same purpose. 

The intend is to finally send the Milvue AI Generated report based on the confirmed results to Nuance. (    Milvue --> |8a AI Report ORU | NuancePS )

Thanks you. 
Thomas 
